### PR TITLE
Exclude repository configuration files from generated release tarballs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+.git*      	export-ignore
+.travis.yml	export-ignore


### PR DESCRIPTION
having files like `.gitignore` in the automatically generated tarballs is problematic as it interferes with downstream repositories (e.g. for the Debian package).

this PR adds a `.gitattributes` file that makes sure that some common repository configurations are excluded.